### PR TITLE
Fix BuildExists QR logic

### DIFF
--- a/simplesqlite3.pas
+++ b/simplesqlite3.pas
@@ -183,8 +183,11 @@ var
   r: integer;
 begin
   q := NewQuery(DBObj);
-  q.SQL.Text := 'select count(BuildID) BuildCount from BuildList where QRCode=:QRCode';
-  q.Params.ParamValues['QRCode'] := QRCode;
+  // BuildList stores QR strings in the BuildQR column defined in
+  // databasemanager.DefineBuildList. Query that field to avoid a
+  // "QRCode" reference that doesn't exist in the table schema.
+  q.SQL.Text := 'select count(BuildID) BuildCount from BuildList where BuildQR=:BuildQR';
+  q.Params.ParamValues['BuildQR'] := QRCode;
   q.Open;
   r := q.FieldByName('BuildCount').AsInteger;
   EndQuery(q);


### PR DESCRIPTION
## Summary
- clarify that the QR lookup goes through the `BuildQR` column
- update the query parameter naming to match the table schema

## Testing
- `fpc simplesqlite3.pas`
- `fpc BuildDatabase.lpr` *(fails: Can't find unit Interfaces)*

------
https://chatgpt.com/codex/tasks/task_e_683f3a8006e8832c99170b01bd5127d7